### PR TITLE
Link Related Questions to Existing Posts or Chat Pre-fill

### DIFF
--- a/assets/js/bridge-listener.js
+++ b/assets/js/bridge-listener.js
@@ -192,3 +192,49 @@ function getDeepFlattenedClone(node) {
   console.log("MilePoint Bridge: Polling started (1s)");
   setInterval(runPoll, pollInterval);
 })();
+
+/**
+ * FEATURE: Pre-fill Chat Input from URL Param
+ */
+(function () {
+  const urlParams = new URLSearchParams(window.location.search);
+  const question = urlParams.get("q");
+
+  if (!question) return;
+
+  console.log("MilePoint Bridge: Found question param:", question);
+
+  // Poll for the prompt element
+  const maxAttempts = 30; // 30 seconds approx
+  let attempts = 0;
+
+  const pollForPrompt = setInterval(() => {
+    attempts++;
+    if (attempts > maxAttempts) {
+      clearInterval(pollForPrompt);
+      console.log("MilePoint Bridge: Timed out waiting for chat prompt.");
+      return;
+    }
+
+    const promptHost = document.getElementById("prompt-host");
+    if (!promptHost) return;
+
+    const promptComponent = promptHost.querySelector("gist-chat-prompt");
+    if (!promptComponent || !promptComponent.shadowRoot) return;
+
+    const textarea = promptComponent.shadowRoot.querySelector("textarea");
+
+    if (textarea) {
+      clearInterval(pollForPrompt);
+      console.log("MilePoint Bridge: Chat prompt found. Injecting question.");
+
+      // Inject and trigger events
+      textarea.value = question;
+      textarea.dispatchEvent(new Event("input", { bubbles: true }));
+      textarea.dispatchEvent(new Event("change", { bubbles: true }));
+
+      // Optional: Focus
+      textarea.focus();
+    }
+  }, 1000);
+})();

--- a/includes/class-content-template.php
+++ b/includes/class-content-template.php
@@ -280,12 +280,25 @@ class MP_Content_Template
 
       foreach ($related as $q) {
         $clean_q = $this->clean_lit_comments($q);
+
+        // 1. Check if post exists
+        $existing_post = get_page_by_title($clean_q, OBJECT, 'milepoint_qa');
+
+        if ($existing_post && $existing_post->post_status === 'publish') {
+            $link_url = get_permalink($existing_post->ID);
+        } else {
+            // 2. Fallback to Chat URL with query param
+            // Assuming /chat/ is the slug. We can also use site_url('/chat/')
+            $link_url = site_url('/chat/') . '?q=' . urlencode($clean_q);
+        }
+
+        // We change the outer div to an anchor tag, keeping the same styles + display:block + text-decoration:none
         $html .=
-          '<div style="color: #0073aa; font-size: 1.1rem; padding: 16px 20px; background: #fff; border: 1px solid #f0f0f0; border-radius: 8px;">';
+          '<a href="' . esc_url($link_url) . '" style="text-decoration: none; display: block; color: #0073aa; font-size: 1.1rem; padding: 16px 20px; background: #fff; border: 1px solid #f0f0f0; border-radius: 8px; transition: all 0.2s ease;">';
         $html .=
           '  <span style="margin-right: 12px; color: #0073aa; opacity: 0.4; font-weight: bold;">→</span> ' .
           esc_html($clean_q);
-        $html .= "</div>";
+        $html .= "</a>";
       }
 
       $html .= "  </div>";


### PR DESCRIPTION
Modified related questions section to link to existing posts (via `get_page_by_title`) or fallback to chat page with query parameter. Added JS logic to pre-fill chat input from query parameter.

---
*PR created automatically by Jules for task [11631656695784170985](https://jules.google.com/task/11631656695784170985) started by @BoardingAI*